### PR TITLE
Updates the governor management

### DIFF
--- a/script/zeetaatweaks.sh
+++ b/script/zeetaatweaks.sh
@@ -29,15 +29,36 @@ echo " " >> $LOG
 # Credits to Kdrag0n
 echo "$(date "+%H:%M:%S") * Applying Google's schedutil rate-limits from Pixel 3" >> $LOG
 sleep 0.5
+
+SchedutilCheck=$(grep schedutil /sys/devices/system/cpu/cpufreq/policy0/scaling_available_governors)
+
+# find if in kernel source is present schedutil
+if [ "$SchedutilCheck" ]; then
+  echo "$(date "+%H:%M:%S") * Schedutil governor is present in this kernel"
+  # check if is select by default (or set it)
+  if [ $(grep schedutil /sys/devices/system/cpu/cpufreq/policy0/scaling_governor) ]; then
+    echo "$(date "+%H:%M:%S") * Schedutil governor is already select"
+  else
+    for cluster in /sys/devices/system/cpu/cpufreq/*/
+    do
+      echo "schedutil" > "${cluster}"/scaling_governor
+    done
+    echo "$(date "+%H:%M:%S") * Schedutil governor selected"
+  fi
+fi
+
+# Now, if schedutil governor is set correctly and is the standard linux version, set the tweaks
+# But only if this gevernor version allow for change value
 if [ -e $SC ]; then
-for cpu in /sys/devices/system/cpu/*/cpufreq/schedutil
-do
-echo 1000 > "${cpu}"/up_rate_limit_us
-echo 20000 > "${cpu}"/down_rate_limit_us
-done
+  for cpu in /sys/devices/system/cpu/*/cpufreq/schedutil
+  do
+    echo 1000 > "${cpu}"/up_rate_limit_us
+    echo 20000 > "${cpu}"/down_rate_limit_us
+  done
   echo "$(date "+%H:%M:%S") * Applied Google's schedutil rate-limits from Pixel 3" >> $LOG
-else
-  echo "$(date "+%H:%M:%S") * Abort You are not using schedutil governor" >> $LOG
+# it could also be a modified version that doesn't use sprintf() functions
+#else
+#  echo "$(date "+%H:%M:%S") * Abort You are not using schedutil governor" >> $LOG
 fi
 echo " " >> $LOG
   


### PR DESCRIPTION
Before this patch:
	Check if the version of the governor (schedutil) has value checking via /sys/
	Based on this you decide whether schedutil is used or not.

Revision data:
- Since control nodes may not even be present on some (even modified) versions of schedutil governor, we must not rely on this.
- The kernel that has schedutil does not always boot with this governor (it depends on the DT). then set it as the current governor.

After this patch:
	Check if the kernel contains schedutil governor, and set it.
	Check if it has control nodes, otherwise do nothing.

Patch tested on:
- GNU bash, version 5.0.16(1)-release (x86_64-pc-linux-gnu)
- Linux Kernel version 5.4.0-26-generic

Signed-off-by: Peppe289 <gsperanza204@gmail.com>